### PR TITLE
Make URLs configurable

### DIFF
--- a/lib/passport-yammer/strategy.js
+++ b/lib/passport-yammer/strategy.js
@@ -47,6 +47,7 @@ function Strategy(options, verify) {
   
   OAuth2Strategy.call(this, options, verify);
   this.name = 'yammer';
+  this.userProfileURL = options.userProfileURL || 'https://www.yammer.com/api/v1/users/current.json';
   
   // Despite claiming to support the OAuth 2.0 specification, Yammer's
   // implementation does anything but.  Yammer's token endpoint returns a
@@ -98,7 +99,7 @@ util.inherits(Strategy, OAuth2Strategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(accessToken, done) {
-  this._oauth2.get('https://www.yammer.com/api/v1/users/current.json', accessToken, function (err, body, res) {
+  this._oauth2.get(this.userProfileURL, accessToken, function (err, body, res) {
     if (err) { return done(err); }
     
     try {


### PR DESCRIPTION
People are wanting to use Geddy's Passport integration with Yammer's staging instance, which has a different host name from www.yammer.com. This pull-request allows devs to override all the URLs for Yammer auth, including the one for retrieving profile-data, which was not configurable.
